### PR TITLE
Add extraClangArguments option

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,6 +3,7 @@ const path = require('path')
 
 const { spawn } = require('child_process')
 const { AutoLanguageClient } = require('atom-languageclient')
+const shellParse = require('shell-quote').parse
 
 class CqueryLanguageClient extends AutoLanguageClient {
   getGrammarScopes () { return [ 'source.c', 'source.cpp' ] }

--- a/lib/main.js
+++ b/lib/main.js
@@ -30,7 +30,8 @@ class CqueryLanguageClient extends AutoLanguageClient {
       {
         snippetSupport: atom.config.get("ide-cquery.enableSnippetInsertion"),
       },
-      includeCompletionWhitelistLiteralEnding: [".h", ".hpp"]
+      includeCompletionWhitelistLiteralEnding: [".h", ".hpp"],
+      extraClangArguments: shellParse(atom.config.get("ide-cquery.extraClangArguments").join(" "))
     };
     return params;
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.6.3"
+    "atom-languageclient": "^0.6.3",
+    "shell-quote": "^1.6.1"
   },
   "devDependencies": {
     "snazzy": "^7.0.0",
@@ -115,6 +116,14 @@
     "logFile": {
       "type": "string",
       "default": "cquery_log.txt"
+    },
+    "extraClangArguments": {
+      "type": "array",
+      "default": [],
+      "description": "Additional arguments to pass to clang",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
Add the ability to specify extra clang arguments to the cquery initialize object. This is useful to add arguments that should always be used with clang, regardless of what compile_commands.json claims should be used.

I created a new config option called extraClangArguments which allows users to specify those extra arguments. cquery expects the arguments to in an array, and Atom does array splits on commas, not spaces. As a result, I added a dependency, shell-quote which will parse shell arguments (and respect quotation marks) to do the splitting correctly so that users can just type out the extra arguments in the field. It is possible to just require users to comma separate the argument list, but this should be a bit of a nicer experience for users, but the description should be updated to note this.