### PR TITLE
Update atom-languageclient, add signature help consumer

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
       "versions": {
         "0.1.0": "consumeDatatip"
       }
+    },
+    "signature-help": {
+      "versions": {
+        "0.1.0": "consumeSignatureHelp"
+      }
     }
   },
   "providedServices": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.9.1"
+    "atom-languageclient": "^0.9.3"
   },
   "devDependencies": {
     "snazzy": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.6.3"
+    "atom-languageclient": "^0.9.1"
   },
   "devDependencies": {
     "snazzy": "^7.0.0",


### PR DESCRIPTION
- Updating atom-languageclient to the latest version, 0.9.1. After a very quick test, this might resolve cquery-project/cquery#514.
- Added signature help consumer, since cquery provides it and atom-languageclient automatically configures it.
