### PR TITLE
Add busy-signal handler on $cquery/progress; simplify cquery process creation

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -58,40 +58,8 @@ class CqueryLanguageClient extends AutoLanguageClient {
     }
 
     this.logger.debug(`Starting ${command} ${args.join(' ')}`)
-    const serverProcess = spawn(command, args, options)
-    // atom.notifications.addInfo('Starting cquery...',{dismissable:true, description:''})
 
-    serverProcess.on('exit', (code, signal) =>
-      atom.notifications.addInfo('Cquery terminated', {dismissable: true, description:`Something bad happened to cquery, Error Code: ${code}, Error Signal ${signal}`}));
-
-
-    serverProcess.on('error', error => {
-      if (error.code === 'ENOENT') {
-        atom.notifications.addError(`Unable to start ${this.getServerName()} language server`, {
-          dismissable: true,
-          description: '' +
-            `Tried to spawn process using executable **${error.path}**, which does not exist. ` +
-            `Ensure you have correctly configured the path to cquery in the package settings.`
-        })
-      }
-    })
-    // serverProcess.stdin.setEncoding('utf8')
-    // serverProcess.stdin.on('data', (data) => {
-    //   atom.notifications.addError(data.toString(), {dismissable:true, description:''})
-    // })
-
-    ////Pipe Debug Info to files
-    // var fs = require("fs")
-    // var file = fs.createWriteStream(`${projectPath}stdin.txt`)
-    // serverProcess.stdin.pipe(file)
-    //
-    // var file = fs.createWriteStream(`${projectPath}stdout.txt`)
-    // serverProcess.stdout.pipe(file)
-    //
-    // var file = fs.createWriteStream(`${projectPath}stderr.txt`)
-    // serverProcess.stderr.pipe(file)
-
-    return (serverProcess)
+    return spawn(command, args, options)
   }
 
   deactivate() {
@@ -107,6 +75,20 @@ class CqueryLanguageClient extends AutoLanguageClient {
         );
         resolve();
       }, milliseconds);
+    });
+  }
+
+  preInitialization(connection) {
+    connection.onCustom('$cquery/progress', (progress) => {
+      if(progress.activeThreads > 0 && this.busySignalService) {
+        if(!this.cqueryProgressSignal) {
+          this.cqueryProgressSignal = this.busySignalService.reportBusy(`cquery running`)
+        }
+        this.cqueryProgressSignal.setTitle(`cquery running ${progress.activeThreads} thread(s)`)
+      } else if(this.cqueryProgressSignal) {
+        this.cqueryProgressSignal.dispose();
+        this.cqueryProgressSignal = null;
+      }
     });
   }
 }


### PR DESCRIPTION
- When $cquery/progress is recevied, we now signal busy if the active
  thread count is greater than 0. It's difficult to do for any extended
  amount of time, though.
- Simplied the way the server process was created. atom-languageclient
  will handle all of the data/exit/error type events from the child
  process anyway, so no need to do it as well. Also more importantly, we
  don't need to display a notification when the cquery process dies.