### PR TITLE
Add comment parsing and detailed completion configuration

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -32,7 +32,16 @@ class CqueryLanguageClient extends AutoLanguageClient {
         snippetSupport: atom.config.get("ide-cquery.enableSnippetInsertion"),
       },
       includeCompletionWhitelistLiteralEnding: [".h", ".hpp"],
-      extraClangArguments: shellParse(atom.config.get("ide-cquery.extraClangArguments").join(" "))
+      extraClangArguments: shellParse(atom.config.get("ide-cquery.extraClangArguments").join(" ")),
+      index:
+      {
+        comments: atom.config.get("ide-cquery.commentParsing")
+      },
+      completion:
+      {
+        detailedLabel: atom.config.get("ide-cquery.detailedCompletionLabel"),
+        filterAndSort: false
+      }
     };
     return params;
   }

--- a/package.json
+++ b/package.json
@@ -134,6 +134,21 @@
     "logFile": {
       "type": "string",
       "default": "cquery_log.txt"
+    },
+    "commentParsing": {
+      "type": "integer",
+      "default": 2,
+      "enum": [
+        { "value": 0, "description": "None" },
+        { "value": 1, "description": "Doxygen-Style" },
+        { "value": 2, "description": "All comments" }
+      ],
+      "description": "Instruct cquery how to parse comments"
+    },
+    "detailedCompletionLabel": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable detailed completion labels (complete signature in autocomplete)."
     }
   }
 }


### PR DESCRIPTION
- Added comment parsing configuration to forward onto cquery
  configuration options
https://github.com/cquery-project/cquery/blob/master/src/config.h#L187-L191
- Added detailed completion information configuration
https://github.com/cquery-project/cquery/blob/master/src/config.h#L91-L108
- Disabled filtering and sorting completion results (Atom will do it, cquery should not)
https://github.com/cquery-project/cquery/blob/master/src/config.h#L116-L121
atom/atom-languageclient#201