### PR TITLE
Add textDocumentView, make file watcher more robust for updates to config files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -3,7 +3,7 @@ const path = require('path')
 
 const { watchPath } = require('atom')
 const { spawn } = require('child_process')
-const { AutoLanguageClient } = require('atom-languageclient')
+const { AutoLanguageClient, Convert } = require('atom-languageclient')
 const shellParse = require('shell-quote').parse
 
 class CqueryLanguageClient extends AutoLanguageClient {
@@ -49,8 +49,6 @@ class CqueryLanguageClient extends AutoLanguageClient {
 
   startServerProcess (projectPath) {
     this.projectPath = projectPath
-
-    atom.config.set('core.debugLSP', true)
 
     const command = atom.config.get('ide-cquery.cqueryPath')
     const doLogging = atom.config.get('ide-cquery.enableLogging')
@@ -103,12 +101,30 @@ class CqueryLanguageClient extends AutoLanguageClient {
   }
 
   postInitialization(server) {
-    watchPath(`${server.projectPath}/compile_commands.json`, {}, events => {
-      server.connection.didChangeConfiguration({});
-    }).then(watcher => server.disposable.add(watcher));
-    watchPath(`${server.projectPath}/.cquery`, {}, events => {
-      server.connection.didChangeConfiguration({});
-    }).then(watcher => server.disposable.add(watcher));
+    server.disposable.add(atom.project.onDidChangeFiles(events => {
+      if(events.some((event) => {
+        let paths = atom.project.relativizePath(event.path);
+        this.logger.debug(paths);
+        return !path.relative(paths[0], server.projectPath) && (paths[1] == 'compile_commands.json' || paths[1].endsWith('.cquery'));
+      })) {
+        server.connection.didChangeConfiguration({});
+      }
+    }));
+
+    server.disposable.add(atom.workspace.onDidChangeActiveTextEditor(editor => {
+      let paths = atom.project.relativizePath(editor.getPath());
+      if(!path.relative(paths[0], server.projectPath)) {
+        server.connection.sendCustomRequest('$cquery/textDocumentDidView', {textDocumentUri: Convert.pathToUri(editor.getPath())});
+      }
+    }));
+
+    let editor = atom.workspace.getActiveTextEditor();
+    if(editor) {
+      let paths = atom.project.relativizePath(editor.getPath());
+      if(!path.relative(paths[0], server.projectPath)) {
+        server.connection.sendCustomRequest('$cquery/textDocumentDidView', {textDocumentUri: Convert.pathToUri(editor.getPath())});
+      }
+    }
   }
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,7 +1,6 @@
 const fs = require('fs')
 const path = require('path')
 
-const { watchPath } = require('atom')
 const { spawn } = require('child_process')
 const { AutoLanguageClient, Convert } = require('atom-languageclient')
 const shellParse = require('shell-quote').parse
@@ -104,7 +103,6 @@ class CqueryLanguageClient extends AutoLanguageClient {
     server.disposable.add(atom.project.onDidChangeFiles(events => {
       if(events.some((event) => {
         let paths = atom.project.relativizePath(event.path);
-        this.logger.debug(paths);
         return !path.relative(paths[0], server.projectPath) && (paths[1] == 'compile_commands.json' || paths[1].endsWith('.cquery'));
       })) {
         server.connection.didChangeConfiguration({});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "atom": ">=1.21.0"
   },
   "dependencies": {
-    "atom-languageclient": "^0.9.3",
+    "atom-languageclient": "^0.9.5",
     "shell-quote": "^1.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Summary:
- Use the project file watcher to detect changes to .cquery or compile_commands.json files. This is more robust against file deletion/addition at runtime.
- Add file watcher to send $cquery/textDocumentDidView (which sends inactiveRegions, semanticHighlighting, and some other changes on cquery's end)

Test Plan:
- [X] textDocumentDidView sent whenever the active editor is changed and see responses from cquery
- [X] textDocumentDidView is sent and see responses from cquery when server starts
- [X] didChangeConfiguration sent even when file is newly created or deleted