### PR TITLE
option to enable/disable formatting

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -9,6 +9,11 @@ module.exports = {
     default: false,
     description: "Enable logging for debugging ide-cquery and cquery"
   },
+  formatting: {
+    type: "boolean",
+    default: true,
+    description: "Enable code formatting"
+  },
   logFile: {
     type: "string",
     default: "cquery_log.txt"

--- a/lib/main.js
+++ b/lib/main.js
@@ -84,6 +84,8 @@ class CqueryLanguageClient extends AutoLanguageClient {
     options["highlight"] = {}
     options["highlight"]["enabled"] = atom.config.get('ide-cquery.enableSemanticHighlighting')
     options["emitInactiveRegions"] = atom.config.get('ide-cquery.enableSetInactiveRegions')
+    options["formatting"] = {}
+    options["formatting"]["enabled"] = atom.config.get('ide-cquery.formatting')
     return options;
   }
 


### PR DESCRIPTION
I prefer to use some other packages for code formatting (atom-beautify in my case) since they generally offer more customization options. I guess I'm not the only one in this situation so this PR adds a configuration option to enable or disable code formatting by this plugin.

The option is defaulted to true to keep a consistent behavior with the current version of `ide-cquery`.